### PR TITLE
Small code cleanups and file navigation enhancements

### DIFF
--- a/firmware/User/MSXTerminal.c
+++ b/firmware/User/MSXTerminal.c
@@ -17,6 +17,19 @@ uint32_t volatile enableTerminal = 0;
 int PointerX = 1;
 int PointerY = 1;
 
+FATFS fs;
+void MountFilesystem(void) {
+    FRESULT fres;
+
+    // Mount the filesystem
+    do {
+        fres = f_mount (&fs, "", 1);
+        if (fres != FR_OK) {
+            Delay_Ms (500);
+        }
+    } while (fres != FR_OK);
+}
+
 void AutoProgramCart(char *Filename, CartType cartType) {
     FRESULT fres;
     FILINFO fno;
@@ -57,15 +70,7 @@ void Init_MSXTerminal (void) {
     NewLine();
     NewLine();
 
-    FATFS fs;
-    FRESULT fres;
-    // Mount the filesystem
-    do {
-        fres = f_mount (&fs, "", 1);
-        if (fres != FR_OK) {
-            Delay_Ms (500);
-        }
-    } while (fres != FR_OK);
+    MountFilesystem();
 
     // auto program ROMS
     AutoProgramCart("CART.R16", ROM16k);
@@ -251,14 +256,7 @@ void ProcessMSXTerminal (void) {
             appendString (&scb, "Insert USB.");
             menu.FileIndexPage = 1;
             strcpy ((char *)menu.folder, "");
-            FRESULT fres;
-            FATFS fs;
-            do {
-                fres = f_mount (&fs, "", 1);
-                if (fres != FR_OK) {
-                    Delay_Ms (500);
-                }
-            } while (fres != FR_OK);
+            MountFilesystem();
             flushBuffer (&icb);
             PrintMainMenu (menu.FileIndexPage);
         }

--- a/firmware/User/MSXTerminal.c
+++ b/firmware/User/MSXTerminal.c
@@ -17,6 +17,17 @@ uint32_t volatile enableTerminal = 0;
 int PointerX = 1;
 int PointerY = 1;
 
+void AutoProgramCart(char *Filename, CartType cartType) {
+    FRESULT fres;
+    FILINFO fno;
+
+    // auto program
+    fres = f_stat (Filename, &fno);
+    if (fres == FR_OK) {
+        ProgramCart (cartType, Filename, "/");
+    }
+}
+
 void Init_MSXTerminal (void) {
     initBuffer (&scb);
     initMiniBuffer (&icb);
@@ -48,7 +59,6 @@ void Init_MSXTerminal (void) {
 
     FATFS fs;
     FRESULT fres;
-    FILINFO fno;
     // Mount the filesystem
     do {
         fres = f_mount (&fs, "", 1);
@@ -57,56 +67,17 @@ void Init_MSXTerminal (void) {
         }
     } while (fres != FR_OK);
 
-    // auto program
-    fres = f_stat ("CART.R16", &fno);
-    if (fres == FR_OK) {
-        ProgramCart (ROM16k, "CART.R16", "/");
-    }
-
-    fres = f_stat ("CART.R32", &fno);
-    if (fres == FR_OK) {
-        ProgramCart (ROM32k, "CART.R32", "/");
-    }
-
-    fres = f_stat ("CART.R48", &fno);
-    if (fres == FR_OK) {
-        ProgramCart (ROM48k, "CART.R48", "/");
-    }
-
-    fres = f_stat ("CART.KO4", &fno);
-    if (fres == FR_OK) {
-        ProgramCart (KonamiWithoutSCC, "CART.KO4", "/");
-    }
-
-    fres = f_stat ("CART.KO5", &fno);
-    if (fres == FR_OK) {
-        ProgramCart (KonamiWithSCC, "CART.KO5", "/");
-    }
-
-    fres = f_stat ("CART.KD5", &fno);
-    if (fres == FR_OK) {
-        ProgramCart (KonamiWithSCCNOSCC, "CART.KD5", "/");
-    }
-
-    fres = f_stat ("CART.A8K", &fno);
-    if (fres == FR_OK) {
-        ProgramCart (ASCII8k, "CART.A8K", "/");
-    }
-
-    fres = f_stat ("CART.A16", &fno);
-    if (fres == FR_OK) {
-        ProgramCart (ASCII16k, "CART.A16", "/");
-    }
-
-    fres = f_stat ("CART.N16", &fno);
-    if (fres == FR_OK) {
-        ProgramCart (NEO16, "CART.N16", "/");
-    }
-
-    fres = f_stat ("CART.N8K", &fno);
-    if (fres == FR_OK) {
-        ProgramCart (NEO8, "CART.N8K", "/");
-    }
+    // auto program ROMS
+    AutoProgramCart("CART.R16", ROM16k);
+    AutoProgramCart("CART.R32", ROM32k);
+    AutoProgramCart("CART.R48", ROM48k);
+    AutoProgramCart("CART.KO4", KonamiWithoutSCC);
+    AutoProgramCart("CART.KO5", KonamiWithSCC);
+    AutoProgramCart("CART.KD5", KonamiWithSCCNOSCC);
+    AutoProgramCart("CART.A8K", ASCII8k);
+    AutoProgramCart("CART.A16", ASCII16k);
+    AutoProgramCart("CART.N16", NEO16);
+    AutoProgramCart("CART.N8K", NEO8);
 
     menu.FileIndexPage = 1;
     strcpy ((char *)menu.folder, "");

--- a/firmware/User/MSXTerminal.c
+++ b/firmware/User/MSXTerminal.c
@@ -50,7 +50,7 @@ void Init_MSXTerminal (void) {
     menu.Filename = (uint8_t *)malloc (255 * sizeof (uint8_t));
     menu.folder = (uint8_t *)malloc (255 * sizeof (uint8_t));
 
-    for (int i = 0; i < 20; i++) {
+    for (int i = 0; i < FILE_ARRAY_SIZE; i++) {
         menu.FileArray[i] = (FileEntry *)malloc (sizeof (FileEntry));
     }
     ClearScreen();
@@ -99,7 +99,7 @@ void PrintMainMenu (int page) {
     menu.pageName = MAIN;
     menu.FileIndex = 0;
     ClearScreen();
-    menu.FileIndexSize = listFiles (menu.folder, menu.FileArray, page);
+    menu.FileIndexSize = listFiles (menu.folder, menu.FileArray, FILE_ARRAY_SIZE, page);
 
 
     appendString (&scb, " ");
@@ -293,7 +293,7 @@ void ProcessMSXTerminal (void) {
         switch (menu.pageName) {
         case MAIN:
             if (key == 0x1C) {
-                if (menu.FileIndexSize < 20)
+                if (menu.FileIndexSize < FILE_ARRAY_SIZE)
                     return;
                 menu.FileIndexPage++;
                 PrintMainMenu (menu.FileIndexPage);

--- a/firmware/User/MSXTerminal.h
+++ b/firmware/User/MSXTerminal.h
@@ -12,6 +12,7 @@ typedef enum page {
 } MenuType;
 
 #define FILE_ARRAY_SIZE 20
+#define MAX_DIR_DEPTH 60
 
 typedef struct TerminalPageState {
     MenuType pageName;
@@ -19,6 +20,8 @@ typedef struct TerminalPageState {
     uint32_t FileIndex;
     uint32_t FileIndexSize;
     uint32_t FileIndexPage;
+    uint16_t FileOffsetStack[MAX_DIR_DEPTH]; // stores file index selected when entering a directory (indexed by directory depth)
+    uint8_t  DirDepth;                       // current directory depth
     uint32_t CartTypeIndex;
     uint8_t *folder;
     FileEntry *FileArray[FILE_ARRAY_SIZE];

--- a/firmware/User/MSXTerminal.h
+++ b/firmware/User/MSXTerminal.h
@@ -11,6 +11,8 @@ typedef enum page {
 
 } MenuType;
 
+#define FILE_ARRAY_SIZE 20
+
 typedef struct TerminalPageState {
     MenuType pageName;
 
@@ -19,7 +21,7 @@ typedef struct TerminalPageState {
     uint32_t FileIndexPage;
     uint32_t CartTypeIndex;
     uint8_t *folder;
-    FileEntry *FileArray[20];
+    FileEntry *FileArray[FILE_ARRAY_SIZE];
     uint8_t *Filename;
 } MenuState;
 

--- a/firmware/User/utils.c
+++ b/firmware/User/utils.c
@@ -139,10 +139,10 @@ int strToInt (const char *str) {
     return result;
 }
 
-int listFiles (uint8_t folder[255], FileEntry *FileArray[20], int page) {
+int listFiles (uint8_t folder[255], FileEntry *FileArray[], int FileArraySize, int page) {
     DIR dir;
     FILINFO fno;
-    int firstItem = (page - 1) * 20;
+    int firstItem = (page - 1) * FileArraySize;
     int size = 0;
     int idx = 0;
     FRESULT fres;
@@ -171,8 +171,8 @@ int listFiles (uint8_t folder[255], FileEntry *FileArray[20], int page) {
         idx++;
     }
 
-    // Collect up to 20 entries for this page
-    while (size < 20) {
+    // Collect up to FileArraySize entries for this page
+    while (size < FileArraySize) {
         fres = f_readdir (&dir, &fno);
         if (fres != FR_OK || fno.fname[0] == 0) {
             break;

--- a/firmware/User/utils.h
+++ b/firmware/User/utils.h
@@ -36,7 +36,7 @@ void waitBufferEmpty(CircularBuffer *cb) ;
 int strToInt (const char *str);
 void intToString (int num, char *str);
 
-int listFiles (uint8_t folder[64], FileEntry *FileArray[20], int page);
+int listFiles (uint8_t folder[64], FileEntry *FileArray[], int FileArraySize, int page);
 void CombinePath (char *dest, const char *folder, const char *filename);
 
 #endif  // CIRCULAR_BUFFER_H


### PR DESCRIPTION
This PR consolidates some functions for clarity, and enhances navigating the filesystem by returning to the previous point in the directory tree when going back from a directory (backspace) or mapper screen (esc), instead of going to the first entry unconditionally. This is useful when browsing USB drives with large number of files or deep directory structures.